### PR TITLE
Rework approach of mixing to match latest Spectral.js

### DIFF
--- a/coloraide_extras/__meta__.py
+++ b/coloraide_extras/__meta__.py
@@ -193,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 10, 0, "final")
+__version_info__ = Version(1, 10, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.1
+
+-   **ENHANCE**: Update internal algorithm of Spectral mixing which is more efficient.
+
 ## 1.10
 
 -   **NEW**: Sync types with latest ColorAide and require the latest ColorAide.

--- a/docs/theme/playground-config-33c95a6c.js
+++ b/docs/theme/playground-config-33c95a6c.js
@@ -1,5 +1,0 @@
-var colorNotebook = {
-    "playgroundWheels": ['micropip', 'pygments-2.19.1-py3-none-any.whl', 'coloraide-4.6-py3-none-any.whl', 'coloraide_extras-1.10-py3-none-any.whl'],
-    "notebookWheels": ['pyyaml', 'Markdown-3.7-py3-none-any.whl', 'pymdown_extensions-10.14.1-py3-none-any.whl', 'micropip', 'pygments-2.19.1-py3-none-any.whl', 'coloraide-4.6-py3-none-any.whl', 'coloraide_extras-1.10-py3-none-any.whl'],
-    "defaultPlayground": "from coloraide_extras.everything import ColorAll as Color\ncoloraide.__version__\ncoloraide_extras.__version__\nColor('color(--ucs 0.27493 0.21264 0.12243 / 1)')"
-}

--- a/docs/theme/playground-config-68525240.js
+++ b/docs/theme/playground-config-68525240.js
@@ -1,0 +1,5 @@
+var colorNotebook = {
+    "playgroundWheels": ['micropip', 'pygments-2.19.1-py3-none-any.whl', 'coloraide-4.6-py3-none-any.whl', 'coloraide_extras-1.10.1-py3-none-any.whl'],
+    "notebookWheels": ['pyyaml', 'Markdown-3.7-py3-none-any.whl', 'pymdown_extensions-10.14.1-py3-none-any.whl', 'micropip', 'pygments-2.19.1-py3-none-any.whl', 'coloraide-4.6-py3-none-any.whl', 'coloraide_extras-1.10.1-py3-none-any.whl'],
+    "defaultPlayground": "from coloraide_extras.everything import ColorAll as Color\ncoloraide.__version__\ncoloraide_extras.__version__\nColor('color(--ucs 0.27493 0.21264 0.12243 / 1)')"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,7 +210,7 @@ extra_css:
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/ace-builds@1.39.0/src-min-noconflict/ace.js
   - https://cdn.jsdelivr.net/npm/mermaid@11.5.0/dist/mermaid.min.js
-  - playground-config-33c95a6c.js
+  - playground-config-68525240.js
   - https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js
   - assets/coloraide-extras/extra-notebook-CuRWK8GL.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/tools/plot_reflect.py
+++ b/tools/plot_reflect.py
@@ -78,7 +78,7 @@ def main():
             if i == -1:
                 continue
 
-            t = spectral.nonlinear_luminance_ease(xyz[1], xyz2[1], i)
+            c1, c2 = spectral.calculate_mixing_concentration(i, xyz[1], xyz2[1])
             size = len(r1)
             r = [0.0] * size
             for i in range(size):
@@ -86,7 +86,7 @@ def main():
                 ks2 = (1 - r2[i]) ** 2 / (2 * r2[i])
 
                 # Perform the actual interpolation
-                ks = alg.lerp(ks1, ks2, t)
+                ks = ks1 * c1 + ks2 * c2
 
                 r[i] = (1 + ks - alg.nth_root(ks ** 2 + 2 * ks, 2))
 
@@ -97,7 +97,7 @@ def main():
             else:
                 target.append(r)
                 xyza = spectral.reflectance_to_xyz(r)
-                xyzb = [alg.lerp(r1, r2, t) for r1, r2 in zip(res1, res2)]
+                xyzb = [alg.lerp(r1, r2, i) for r1, r2 in zip(res1, res2)]
                 xyz_final = [xyza[0] + xyzb[0], xyza[1] + xyzb[1], xyza[2] + xyzb[2]]
                 color3 = Color('xyz-d65', xyz_final)
                 plot.append(color3.convert('srgb').to_string(hex=True))


### PR DESCRIPTION
The actual implementation works exactly the same, but it is calculated a bit different. Instead of adjusting the progress and then applying lerp on each KS, the calculations are reworked to calculate mixing concentrations. Then each KS can just be multiplied by the concentration and summed with the other colors KS and concentration. This follows more closely to what is being done in Spectral.js 3+.